### PR TITLE
Fix handling of backwards compatibility - broken in AOSP too?

### DIFF
--- a/jni/_system_properties.h
+++ b/jni/_system_properties.h
@@ -84,13 +84,11 @@ struct prop_area_compat {
     unsigned volatile serial;
     unsigned magic;
     unsigned version;
+    unsigned reserved[4];
     unsigned toc[1];
 };
 
 typedef struct prop_area_compat prop_area_compat;
-
-struct prop_area;
-typedef struct prop_area prop_area;
 
 struct prop_info_compat {
     char name[PROP_NAME_MAX];


### PR DESCRIPTION
Previously, the prop_info_compat structure was copied from Bionic in the android-4.4_r1.1 tag. However, that structure is incorrect! Fix the structure and rework the code to use the correct structs depending on the compat_mode flag. Also demotes a couple of LOGE to LOGD.
